### PR TITLE
order resources

### DIFF
--- a/course-v2/layouts/partials/resource_list.html
+++ b/course-v2/layouts/partials/resource_list.html
@@ -1,23 +1,44 @@
+{{ define "renderSortedResources" }}
+  {{ $resources := .resources }}
+  {{ range .resourcesToRender }}
+    {{- partial "resource_list_item.html" (dict "params" . "permalink" (index $resources .resourceIndex).Permalink "hideThumbnail" .hideThumbnail "hideDownloadIcon" .hideDownloadIcon) -}}
+    <hr>
+  {{end}}
+{{ end }}
+
+{{ define "renderResources" }}
+  {{ range .resources }}
+    {{- partial "resource_list_item.html" (dict "params" .Params "permalink" .Permalink "hideThumbnail" .hideThumbnail "hideDownloadIcon" .hideDownloadIcon) -}}
+    <hr>
+  {{end}}
+{{ end }}
+
 {{- $hideThumbnail := .hideThumbnail | default false -}}
 {{- $hideDownloadIcon := .hideDownloadIcon | default false -}}
 {{- $defaultSort := .sort | default true -}}
-
 {{ $resources := .resources }}
 {{ $numberOfResources := len $resources }}
-
 {{ $limitResources := .limitResources | default $numberOfResources }}
+{{ $paramsWithNumericTitles := slice}}
+{{ $paramsWithAlphabeticTitles := slice}}
 
 {{ if gt $numberOfResources 0 }}
   {{ if $defaultSort }}
-    {{ range sort (first $limitResources $resources) .Params "title" }}
-      {{- partial "resource_list_item.html" (dict "params" .Params "permalink" .Permalink "hideThumbnail" $hideThumbnail "hideDownloadIcon" $hideDownloadIcon) -}}
-      <hr>
-    {{end}}
+    {{ template "renderResources" (dict "resources" sort (first $limitResources $resources) .Params "title") "hideThumbnail" $hideThumbnail "hideDownloadIcon" $hideDownloadIcon   }}
   {{ else }}
-    {{ range (first $limitResources $resources)}}
-      {{- partial "resource_list_item.html" (dict "params" .Params "permalink" .Permalink "hideThumbnail" $hideThumbnail "hideDownloadIcon" $hideDownloadIcon) -}}
-      <hr>
+    {{ range $resourceIndex, $resource:= (first $limitResources $resources) }}
+      {{ $numericalTitle :=  (index (findRE `\d+` .Params.title) 0) }}
+      {{ $paramsWithResourceIndex := merge .Params (dict "resourceIndex" $resourceIndex) }}
+      {{ if $numericalTitle }}
+        {{ $paramsWithNumericTitleAndIndex := merge $paramsWithResourceIndex (dict "numericalTitle" $numericalTitle) }}
+        {{ $paramsWithNumericTitles = $paramsWithNumericTitles | append $paramsWithNumericTitleAndIndex  }}
+      {{ else }}
+        {{ $paramsWithAlphabeticTitleAndIndex := merge $paramsWithResourceIndex (dict "alphabeticalTitle" .Params.title) }}
+        {{ $paramsWithAlphabeticTitles = $paramsWithAlphabeticTitles | append $paramsWithAlphabeticTitleAndIndex }}
+      {{ end }}  
     {{ end }}
+    {{ template "renderSortedResources" (dict "resourcesToRender" (sort ($paramsWithNumericTitles) ".numericalTitle" "asc") "resources" $resources "hideThumbnail" $hideThumbnail "hideDownloadIcon" $hideDownloadIcon ) }}
+    {{ template "renderSortedResources" (dict "resourcesToRender" (sort ($paramsWithAlphabeticTitles) ".alphabeticalTitle" "asc") "resources" $resources "hideThumbnail" $hideThumbnail "hideDownloadIcon" $hideDownloadIcon ) }}
   {{ end }}
 {{ else }}
   {{ partial "no_resources_found.html" }}


### PR DESCRIPTION
ticket 958

#### What's this PR do?
Order resources by lecture number first, and then the remaining resources lexicographically

#### How should this be manually tested?
Go to any menu with videos as resources, and see if lectures are on top and in ascending order. Same for other resources at bottom.

