### PR TITLE
sass-resources-loader to load bootstrap only once

### DIFF
--- a/base-theme/assets/css/bootstrap.scss
+++ b/base-theme/assets/css/bootstrap.scss
@@ -1,0 +1,2 @@
+@import "~bootstrap/scss/bootstrap";
+@import "~offcanvas-bootstrap/src/sass/bootstrap.offcanvas";

--- a/base-theme/assets/css/main.scss
+++ b/base-theme/assets/css/main.scss
@@ -2,8 +2,6 @@
 @import "imports/_mixins";
 @import "bootstrap-overrides";
 @import "variables";
-@import "~bootstrap/scss/bootstrap";
-@import "~offcanvas-bootstrap/src/sass/bootstrap.offcanvas";
 
 @import "breakpoints";
 @import "border";

--- a/base-theme/assets/webpack/webpack.common.ts
+++ b/base-theme/assets/webpack/webpack.common.ts
@@ -76,7 +76,13 @@ const config: webpack.Configuration = {
           },
           "css-loader",
           "postcss-loader",
-          "sass-loader"
+          "sass-loader",
+          {
+            loader: 'sass-resources-loader',
+            options: {
+              resources: [fromRoot("./base-theme/assets/css/bootstrap.scss")],
+            },
+          },
         ]
       },
 

--- a/course-v2/assets/css/course-v2.scss
+++ b/course-v2/assets/css/course-v2.scss
@@ -2,8 +2,6 @@
 @import "../../../base-theme/assets/css/bootstrap-overrides";
 @import "../../../base-theme/assets/css/breakpoints";
 @import "../../../base-theme/assets/css/variables";
-@import "~bootstrap/scss/bootstrap";
-@import "~offcanvas-bootstrap/src/sass/bootstrap.offcanvas";
 
 @import "course-nav";
 @import "course-info";

--- a/course/assets/css/course.scss
+++ b/course/assets/css/course.scss
@@ -2,8 +2,6 @@
 @import "../../../base-theme/assets/css/bootstrap-overrides";
 @import "../../../base-theme/assets/css/breakpoints";
 @import "../../../base-theme/assets/css/variables";
-@import "~bootstrap/scss/bootstrap";
-@import "~offcanvas-bootstrap/src/sass/bootstrap.offcanvas";
 
 @import "course-nav";
 @import "course-info";

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "sass": "^1.32.13",
     "sass-lint": "^1.13.1",
     "sass-loader": "^8.0.0",
+    "sass-resources-loader": "^2.2.5",
     "screenfull": "3.2.0",
     "serve-handler": "^6.1.3",
     "shelljs": "^0.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3780,6 +3780,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"async@npm:^3.2.3":
+  version: 3.2.4
+  resolution: "async@npm:3.2.4"
+  checksum: 43d07459a4e1d09b84a20772414aa684ff4de085cbcaec6eea3c7a8f8150e8c62aa6cd4e699fe8ee93c3a5b324e777d34642531875a0817a35697522c1b02e89
+  languageName: node
+  linkType: hard
+
 "asynckit@npm:^0.4.0":
   version: 0.4.0
   resolution: "asynckit@npm:0.4.0"
@@ -13191,6 +13198,7 @@ __metadata:
     sass: ^1.32.13
     sass-lint: ^1.13.1
     sass-loader: ^8.0.0
+    sass-resources-loader: ^2.2.5
     screenfull: 3.2.0
     serve-handler: ^6.1.3
     shelljs: ^0.8.4
@@ -16245,6 +16253,18 @@ __metadata:
     sass:
       optional: true
   checksum: 3e9ba97432fcf1092600a31501298f37a0a913f86086b841740f9f8371ee33de55b9740b31563b089524aeb9020fbc51126730fa51d18b2e724a4ada71e2ff81
+  languageName: node
+  linkType: hard
+
+"sass-resources-loader@npm:^2.2.5":
+  version: 2.2.5
+  resolution: "sass-resources-loader@npm:2.2.5"
+  dependencies:
+    async: ^3.2.3
+    chalk: ^4.1.0
+    glob: ^7.1.6
+    loader-utils: ^2.0.0
+  checksum: 7b406e7b31abd053c4a3a87825bbb20cdf89a5f7e189a4d9cd0607a3e35c1e48a6a680336a34ff842ae71e7f67d95b942bba98cfb2ccb836e98f8e1e371c534c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### What are the relevant tickets?
ticket is 892

#### What's this PR do?
This PR attempts to load bootstrap once by putting it in a global setting and importing it using sass-resources-loader.
This PR **does not** help with resources load/issue resolve (I believe) however it suggests the possibility of bootstrap already being loaded once (but just appearing twice). The thing that matters is the browser load, so if it executes/loads only once but appears twice so it should be okay to go.

#### Any background context you want to provide?
Under the networks tab in CSS, if we go to main.css and course_v2.css we will notice that bootstrap is still appearing twice, with the difference just that now it appears first thing in the top.
My hypothesis is maybe it loads once but appears twice. Because:

Previously we had bootstrap imports in both main.scss file, and course_v2.scss file, so *maybe* it was imported twice, since any mechanism was currently not in place to ensure otherwise.
But now we have removed those duplicate imports, and only put it in one place to import it from. So my understanding is it is imported from there, but it appears in both tabs because both .css files at the end do use bootstrap.

#### Screenshots (if appropriate)
This is our chunks visualization **using** sass-resources-loader
<img width="1630" alt="image" src="https://user-images.githubusercontent.com/109785089/213748895-b528503e-fbc9-4272-b565-4ffa8d1fe856.png">
<img width="665" alt="image" src="https://user-images.githubusercontent.com/109785089/213749080-5d3ff9ba-091a-49f5-977b-f818e4f78c99.png">

And this is the data **without** using sass-resources-loader (with the current github issue)
<img width="1623" alt="image" src="https://user-images.githubusercontent.com/109785089/213750378-f1517469-4f0f-4358-95e6-549b539eb8b9.png">
<img width="650" alt="image" src="https://user-images.githubusercontent.com/109785089/213750111-edf7224a-1424-47da-aa88-6c5d091aa54a.png">

It appears **with** the sass-resources-loader we are a little heavy on .css files.


