### PR TITLE
split chunks of modules to prevent bootstrap duplication

### DIFF
--- a/base-theme/assets/webpack/webpack.common.ts
+++ b/base-theme/assets/webpack/webpack.common.ts
@@ -31,7 +31,23 @@ const config: webpack.Configuration = {
     path:     fromRoot("./base-theme/dist/static"),
     filename: "js/[name].js"
   },
-
+  optimization: {
+    splitChunks: {
+      chunks: 'all',
+      cacheGroups: {
+        vendors: {
+          test: /[\\/]node_modules[\\/](?!(bootstrap))/,
+          name: 'vendors',
+          chunks: 'all',
+        },
+        bootstrap: {
+          test: /[\\/]node_modules[\\/](bootstrap)/,
+          name: 'bootstrap',
+          chunks: 'all',
+        },
+      },
+    },
+  },
   module: {
     rules: [
       {


### PR DESCRIPTION
#### What are the relevant tickets?
ticket is 892

#### What's this PR do?
This PR attempts to load bootstrap only once by putting all other node_modules in a separate cacheGroup, and bootstrap in a different one.

#### Any background context you want to provide?
Same as the other PR related to 892, in this PR bootstrap also appears twice under the network's tab. However, it appears we may have improved our performance (indicated by screenshots). And it might again be true that bootstrap is actually loaded only once.

#### Screenshots (if appropriate)
This is our modules tree visualization using splitChunks inside webpack:
<img width="1626" alt="image" src="https://user-images.githubusercontent.com/109785089/213761025-6a8a8fcb-a464-4bb6-8da1-d1f272d86c59.png">
Other stats:
<img width="648" alt="image" src="https://user-images.githubusercontent.com/109785089/213761147-5b90ff8a-2618-4113-b3a5-f42a01662ea4.png">

And without using splitChunks:
<img width="1623" alt="image" src="https://user-images.githubusercontent.com/109785089/213750378-f1517469-4f0f-4358-95e6-549b539eb8b9.png">
<img width="650" alt="image" src="https://user-images.githubusercontent.com/109785089/213750111-edf7224a-1424-47da-aa88-6c5d091aa54a.png">

